### PR TITLE
회원가입(회원 추가) API에서 profile_image 무시되는 버그 해결

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -4,8 +4,6 @@ from rest_framework import serializers
 User = get_user_model()
 
 class UserSerializer(serializers.ModelSerializer):
-    profile_image = serializers.SerializerMethodField()
-
     class Meta:
         model = User
         fields = ('id','email','password','name','profile_image',)
@@ -18,14 +16,6 @@ class UserSerializer(serializers.ModelSerializer):
         user.set_password(password)
         user.save()
         return user
-
-    def get_profile_image(self, obj):
-        if not obj.profile_image:
-            return None
-
-        profile_image_relative_url = obj.profile_image.url
-        request = self.context.get('request')
-        return request.build_absolute_uri(profile_image_relative_url)
 
 class LoginSerializer(serializers.Serializer):
     email = serializers.EmailField()


### PR DESCRIPTION
## 🔎 What is this PR?
- [API 명세서/회원가입(회원 추가)](https://www.notion.so/2aecc780cd7d80e79739d022184ff91e)
- [API 명세서/회원정보 조회(회원 조회)](https://www.notion.so/2aecc780cd7d8053b245e877e7dd17f1)

## ✨ Changes
- 원인: 필드를 SerializerMethodField로 오버라이드하면 해당 필드는 read_only가 됨.
- 해결: UserSerializer에서 profile_image 필드를 SerializerMethodField로 오버라이드했던 것을 삭제함.
- 시리얼라이저에 context로 request를 넘기면 Django가 자동으로 절대 경로를 반환함. SerializerMethodField를 통해 이미지 URL을 명시적으로 처리하지 않아도 문제 없음. profile_image 필드를 SerializerMethodField로 오버라이드했던 것을 삭제한 후에 회원정보 조회(회원 조회) API 테스트한 결과 절대 경로로 잘 응답함.

## 📷 Result

## 💬 To. Reviewer
