### PR TITLE
학습단계 목록 조회 API 수정: is_unlocked 필드 추가

### DIFF
--- a/missions/serializers.py
+++ b/missions/serializers.py
@@ -15,3 +15,9 @@ class MissionListSerializer(serializers.ModelSerializer):
 
     def get_number(self, obj):
         return obj.id % 10
+
+class MissionListLoginSerializer(MissionListSerializer):
+    is_unlocked = serializers.BooleanField()
+
+    class Meta(MissionListSerializer.Meta):
+        fields = MissionListSerializer.Meta.fields + ('is_unlocked',)

--- a/missions/services.py
+++ b/missions/services.py
@@ -1,6 +1,9 @@
+from django.db.models import Case, Exists, F, OuterRef, Q, Value, When, BooleanField, IntegerField
+from django.db.models.functions import Floor, Mod
 from django.http import HttpRequest
+from solutions.models import SolutionHistory
 from .models import Chapter, Mission
-from .serializers import ChapterListSerializer, MissionListSerializer
+from .serializers import ChapterListSerializer, MissionListSerializer, MissionListLoginSerializer
 
 class ChapterService:
     def __init__(self, request:HttpRequest):
@@ -18,4 +21,38 @@ class MissionService:
     def get_list(self):
         missions = Mission.objects.all().order_by('id')
         mission_list_serializer = MissionListSerializer(missions, many=True)
+        return mission_list_serializer.data
+
+    def get_list_login(self):
+        missions = Mission.objects.annotate(
+            id_mod_10=Mod(F('id'), 10),
+        )
+
+        prev_mission_id = Case(
+            When(id=11, then=Value(None)),
+            When(~Q(id_mod_10=1), then=F('id')-1),
+            When(id_mod_10=1, then=Floor(F('id')/10)*10-10+3),
+            output_field=IntegerField(),
+        )
+
+        prev_mission_is_solved = Exists(
+            SolutionHistory.objects.filter(
+                mission_id=OuterRef('prev_mission_id'),
+                user=self.request.user,
+                is_solved=True,
+            )
+        )
+
+        missions = missions.annotate(
+            prev_mission_id=prev_mission_id,
+            is_unlocked=Case(
+                When(prev_mission_id__isnull=True, then=Value(True)),
+                When(prev_mission_is_solved, then=Value(True)),
+                default=Value(False),
+                output_field=BooleanField(),
+            ),
+        ).all(
+        ).order_by('id')
+
+        mission_list_serializer = MissionListLoginSerializer(missions, many=True)
         return mission_list_serializer.data

--- a/missions/services.py
+++ b/missions/services.py
@@ -2,18 +2,20 @@ from django.http import HttpRequest
 from .models import Chapter, Mission
 from .serializers import ChapterListSerializer, MissionListSerializer
 
-class MissionService:
+class ChapterService:
     def __init__(self, request:HttpRequest):
         self.request = request
 
     def get_list(self):
         chapters = Chapter.objects.all().order_by('id')
-        missions = Mission.objects.all().order_by('id')
-
         chapter_list_serializer = ChapterListSerializer(chapters, many=True)
-        mission_list_serializer = MissionListSerializer(missions, many=True)
+        return chapter_list_serializer.data
 
-        return {
-            "chapter": chapter_list_serializer.data,
-            "mission": mission_list_serializer.data
-        }
+class MissionService:
+    def __init__(self, request:HttpRequest):
+        self.request = request
+
+    def get_list(self):
+        missions = Mission.objects.all().order_by('id')
+        mission_list_serializer = MissionListSerializer(missions, many=True)
+        return mission_list_serializer.data

--- a/missions/views.py
+++ b/missions/views.py
@@ -2,12 +2,26 @@ from django.http import HttpRequest
 from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.permissions import AllowAny, IsAdminUser
+from rest_framework_simplejwt.authentication import JWTAuthentication
 from .services import MissionService
 
 class Root(APIView):
+    authentication_classes = [JWTAuthentication]
+
+    def get_permissions(self):
+        if self.request.method == 'GET':
+            return [AllowAny()]
+        else:
+            return [IsAdminUser()]
+
     def get(self, request:HttpRequest, format=None):
         mission_service = MissionService(request)
-        data = mission_service.get_list()
+
+        if request.user.is_authenticated:
+            data = {'test':'인증됨! 토큰 유효함!'}
+        else:
+            data = mission_service.get_list()
 
         return Response(
             status=status.HTTP_200_OK,

--- a/missions/views.py
+++ b/missions/views.py
@@ -21,7 +21,7 @@ class Root(APIView):
 
         mission_service = MissionService(request)
         if request.user.is_authenticated:
-            mission_list = {'test':'인증됨! 토큰 유효함!'}
+            mission_list = mission_service.get_list_login()
         else:
             mission_list = mission_service.get_list()
 

--- a/missions/views.py
+++ b/missions/views.py
@@ -4,7 +4,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework_simplejwt.authentication import JWTAuthentication
-from .services import MissionService
+from .services import ChapterService, MissionService
 
 class Root(APIView):
     authentication_classes = [JWTAuthentication]
@@ -16,14 +16,19 @@ class Root(APIView):
             return [IsAdminUser()]
 
     def get(self, request:HttpRequest, format=None):
-        mission_service = MissionService(request)
+        chapter_service = ChapterService(request)
+        chapter_list = chapter_service.get_list()
 
+        mission_service = MissionService(request)
         if request.user.is_authenticated:
-            data = {'test':'인증됨! 토큰 유효함!'}
+            mission_list = {'test':'인증됨! 토큰 유효함!'}
         else:
-            data = mission_service.get_list()
+            mission_list = mission_service.get_list()
 
         return Response(
             status=status.HTTP_200_OK,
-            data=data,
+            data={
+                "chapter": chapter_list,
+                "mission": mission_list
+            },
         )

--- a/missions/views.py
+++ b/missions/views.py
@@ -3,11 +3,11 @@ from rest_framework import status
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny, IsAdminUser
-from rest_framework_simplejwt.authentication import JWTAuthentication
+from utils.authentication import OptionalJWTAuthentication
 from .services import ChapterService, MissionService
 
 class Root(APIView):
-    authentication_classes = [JWTAuthentication]
+    authentication_classes = [OptionalJWTAuthentication]
 
     def get_permissions(self):
         if self.request.method == 'GET':

--- a/utils/authentication.py
+++ b/utils/authentication.py
@@ -1,0 +1,8 @@
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+class OptionalJWTAuthentication(JWTAuthentication):
+    def authenticate(self, request):
+        try:
+            return super().authenticate(request)
+        except Exception:
+            return None


### PR DESCRIPTION
## 🔎 What is this PR?
- [API 명세서/학습단계 목록 조회](https://www.notion.so/2abcc780cd7d80b58f95f2ee77f2e1ab)

## ✨ Changes
두 가지 다른 상황에 따라 다른 데이터를 응답합니다.
1. 요청 헤더에 Authorization가 없는 경우(로그인하지 않은 경우) 또는 Authorization가 있으나 토큰 검증 실패할 경우(로그인이 만료됐거나 잘못된 경우)에는 [이렇게](https://www.notion.so/2abcc780cd7d80b58f95f2ee77f2e1ab#2abcc780cd7d806f8ab4d42554202b3f) 응답합니다.
2. 요청 헤더에 Authorization가 있으며 유효한 경우(로그인한 경우)에는 [이렇게](https://www.notion.so/2abcc780cd7d80b58f95f2ee77f2e1ab#2b2cc780cd7d80b297cfc267f3bac97e) `is_unlocked` 필드를 추가하여 응답합니다.

- utils/authentication.py 파일을 추가하고 Custom Authentication Class인 OptionalJWTAuthentication를 정의했습니다.
  - Django는 기본적으로 토큰 검증에 실패하면 바로 예외를 발생시킵니다. Authorization가 있으나 토큰 검증 실패할 경우에도 정상적으로 이후의 코드를 실행하기 위해 OptionalJWTAuthentication를 정의했습니다.
  - View에서 `authentication_classes = [OptionalJWTAuthentication]` 등으로 지정할 수 있습니다.
- `request.user.is_authenticated`를 따져서 로그인한 경우와 로그인하지 않은 경우를 처리합니다.
- MissionService의 get_list 메서드는 로그인하지 않은 경우의 응답을 쿼리하고 직렬화합니다. 단순히 Mission 모델의 모든 레코드를 반환합니다.
- MissionService의 get_list_login 메서드는 로그인한 경우의 응답을 쿼리하고 직렬화합니다. 어떤 학습단계 A의 이전 학습단계 B에 대하여 사용자가 is_solved=True한 풀이기록이 존재하면 A의 is_unlocked=True입니다. 첫 번째 학습단계는 무조건 is_unlocked=True입니다. 그외에는 is_unlocked=False입니다.
- Chapter 모델에 관한 쿼리를 ChapterService로 분리했습니다.
- MissionListLoginSerializer를 추가했습니다. MissionListSerializer에서 `is_unlocked` 필드 하나만 추가했습니다.

## 📷 Result

### 요청 헤더에 Authorization가 없는 경우(로그인하지 않은 경우)
<img src="https://github.com/user-attachments/assets/cf665015-ea4c-4d0b-bcc4-b00cbb55eaf8" />

### Authorization가 있으나 토큰 검증 실패할 경우(로그인이 만료됐거나 잘못된 경우)
<img src="https://github.com/user-attachments/assets/cea69d0e-9bfb-4480-8711-6ae0a00f03d3" />

### 요청 헤더에 Authorization가 있으며 유효한 경우(로그인한 경우)
<img src="https://github.com/user-attachments/assets/b9a72000-a60b-448f-9236-6461c32e227a" />

## 💬 To. Reviewer